### PR TITLE
Request more RAM from Android

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppThemeLight">
+        android:theme="@style/AppThemeLight"
+        android:largeHeap="true">
 
         <meta-data
             android:name="xposedmodule"


### PR DESCRIPTION
There have been a couple of people who have experienced OutOfMemory-Errors while using XPL. The conclusion so far has been that this is a device issue and can't be improved by XPL.

However, while developing an app of mine, I discovered that an OutOfMemory-Error does not actually mean that the device itself is out of memory - it just means that the memory heap allocated to XPL is exhausted. The size of the heap varies between devices and ROMs, but there is a way to request more heap from Android: by simply adding `largeHeap="true"` to `AndroidManifest.xml`. 

This is not guaranteed to be effective, but it could improve the memory situation of some of the people who were having problems.