### PR TITLE
XLuaHook::invoke() must copy all Varargs elements used by the hook.

### DIFF
--- a/app/src/main/java/eu/faircode/xlua/XLua.java
+++ b/app/src/main/java/eu/faircode/xlua/XLua.java
@@ -829,6 +829,10 @@ public class XLua implements IXposedHookZygoteInit, IXposedHookLoadPackage {
             String m = args.arg(2).checkjstring();
             args.arg(3).checkfunction();
             Log.i(TAG, "Dynamic hook " + cls.getName() + "." + m);
+            final LuaValue fun = args.arg(3);
+            final List<LuaValue> xargs = new ArrayList<>();
+            for (int i = 4; i <= args.narg(); i++)
+                xargs.add(args.arg(i));
 
             XposedBridge.hookAllMethods(cls, m, new XC_MethodHook() {
                 @Override
@@ -846,9 +850,9 @@ public class XLua implements IXposedHookZygoteInit, IXposedHookLoadPackage {
                     List<LuaValue> values = new ArrayList<>();
                     values.add(LuaValue.valueOf(when));
                     values.add(CoerceJavaToLua.coerce(new XParam(context, param, settings)));
-                    for (int i = 4; i <= args.narg(); i++)
-                        values.add(args.arg(i));
-                    args.arg(3).invoke(values.toArray(new LuaValue[0]));
+                    for (int i = 0; i < xargs.size(); i++)
+                        values.add(xargs.get(i));
+                    fun.invoke(values.toArray(new LuaValue[0]));
                 }
             });
 


### PR DESCRIPTION
Hi Marcel.

I found this issue when the following code:
```lua
function after(h, p)
  local res = p:getResult()
  hook(res, "foo", dynhook, "foo")
  hook(res, "bar", dynhook, "bar")
end
function dynhook(when, param, name)
  log("when=" .. when .. " name=" .. name)
end
```
started showing in the log `when=XXX name=bar` whenever the foo() or bar() methods were called.  I would expect the log to say `when=XXX name=foo` when foo() is called, and `when=XXX name=bar` when bar() is.

My explanation:
The Varargs object passed to invoke() seems to be reused by the Lua interpreter and capturing it as is when defining the hook leads to accessing other elements than intended when the hook runs. Instead, copy all the function object in fun and the the extra arguments in xargs, and use these when running the hook.

Also, that might explain why the WebView hooks were crashing, and it may not be Xposed's fault :-)