### PR TITLE
Added hooks for getNameForUid(uid) and getPackagesForUid(uid)

### DIFF
--- a/app/src/main/assets/hooks.json
+++ b/app/src/main/assets/hooks.json
@@ -190,6 +190,34 @@
   {
     "collection": "Privacy",
     "group": "Get.Applications",
+    "name": "PackageManager.getNameForUid",
+    "author": "LuigiVampa92",
+    "className": "android.content.pm.PackageManager",
+    "methodName": "getNameForUid",
+    "parameterTypes": [
+      "int"
+    ],
+    "returnType": "java.lang.String",
+    "minSdk": 1,
+    "luaScript": "@generic_null_value"
+  },
+  {
+    "collection": "Privacy",
+    "group": "Get.Applications",
+    "name": "PackageManager.getPackagesForUid",
+    "author": "LuigiVampa92",
+    "className": "android.content.pm.PackageManager",
+    "methodName": "getPackagesForUid",
+    "parameterTypes": [
+      "int"
+    ],
+    "returnType": "[Ljava.lang.String;",
+    "minSdk": 1,
+    "luaScript": "@generic_empty_string_array"
+  },
+  {
+    "collection": "Privacy",
+    "group": "Get.Applications",
     "name": "PackageManager.getPackagesHoldingPermissions",
     "author": "M66B",
     "className": "android.content.pm.PackageManager",


### PR DESCRIPTION
Good day, Marcel. First of all, thanks for amazing work with XPrivacLua! I have a pleasure to use it on my phone as well as your other apps.

I would like to contribute two new hooks for XPrivacyLua that would allow to return empty values for two PackageManager methods that would allow a potential adversary indirectly acquire list of installed apps (current version of XPrivacyLua does not yet hook these methods). I have tested these new hooks on my device and they work great. Haven't faced any errors or issues with them and they also use lua scripts that already presented in repository.

So, the methods are:
PackageManager.getNameForUid(uid)
PackageManager.getPackagesForUid(uid)

The basic idea is that adversary from any unprivileged app can iterate through potential app uids and query PackageManager for package names that correspond to these uids. Executing these methods take some time but it gets the job done after all. Usually uids for system apps start from 1000 and go a bit above this value, and uids for unprivileged apps start from the value of 10000 and increment for all newly installed apps (and thus taking range around 10000-10300). Using getPackagesForUid we can return the same list that is returned by PackageManager.getInstalledApplications() and using getNameForUid approach we can return almost the same list with an exception that this method cannot split apps that have the same shared uid and takes only first of them. Usually system apps have shared uid, so in my case PackageManager.getInstalledApplications() returns 190 entries, PackageManager.getPackagesForUid approach also return same 190 entries and PackageManager.getNameForUid approach returns 150 entries (some shared uid system apps missed, but all user apps are there on the list)

Below are code examples of getting installed app list using these approaches in kotlin:

```
// Returns the same as PackageManager.getInstalledApplications()
// Currently not blocked by XPL
private fun getPackageNamesViaGetPackagesForUid(context: Context): List<String> {
    val packageManager = context.packageManager
    val packages = mutableListOf<String>()
    for (i in 0 until 65535) {
        val pfu = packageManager.getPackagesForUid(i)
        if (pfu != null && pfu.isNotEmpty()) {
            pfu.forEach {
                packages.add(it)
            }
        }
    }
    return packages
}
```

```
// Returns a bit less than PackageManager.getInstalledApplications(). 
// Some shared uid packages will be missing (usually system apps) but 99% of google play apps will be there 
// Currently not blocked by XPL
private fun getPackageNamesViaGetNameForUid(context: Context): List<String> {
    val packageManager = context.packageManager
    val packages = mutableListOf<String>()
    for (i in 0 until 65535) {
        val pfu = packageManager.getNameForUid(i)
        if (pfu != null && pfu.isNotBlank()) {
            packages.add(pfu)
        }
    }
    return packages
}
```

Thank you again and hope you'll be able to include this code into the app.