### PR TITLE
Update DEFINE.md

### DIFF
--- a/DEFINE.md
+++ b/DEFINE.md
@@ -110,13 +110,13 @@ The most important functions of *param* are:
 
 * *param:getApplicationContext()*: see remarks below
 * *param:getThis()*: the current object instance or *nil* if the method is static
-* *param:getArgument(index)*: get the argument at the specified index (one based)
+* *param:getArgument(index)*: get the argument at the specified index (zero-based)
 * *param:setArgument(index, value)*
 * *param:getResult()*: only available after the hooked method has been executed
 * *param:setResult(value)*
 * For other functions, see [here](https://github.com/M66B/XPrivacyLua/blob/master/app/src/main/java/eu/faircode/xlua/XParam.java) for the available public methods
 
-The before/after function should return *true* when something was done and *false* otherwise.
+The before/after function should return *true* when something was done and *false* otherwise. **Returning nil or omitting a return will cause an exception, you must explicitly return a boolean!**
 XPrivacyLua will show the last date/time of the last time *true* was returned.
 
 Special cases

--- a/DEFINE.md
+++ b/DEFINE.md
@@ -116,7 +116,7 @@ The most important functions of *param* are:
 * *param:setResult(value)*
 * For other functions, see [here](https://github.com/M66B/XPrivacyLua/blob/master/app/src/main/java/eu/faircode/xlua/XParam.java) for the available public methods
 
-The before/after function should return *true* when something was done and *false* otherwise. **Returning nil or omitting a return will cause an exception, you must explicitly return a boolean!**
+The before/after function should return *true* when something was done and *false* otherwise. **Returning nil or omitting a return will cause an exception, you should explicitly return a boolean instead.**
 XPrivacyLua will show the last date/time of the last time *true* was returned.
 
 Special cases


### PR DESCRIPTION
This addresses two mistakes in the document:

1. The document stated that param:getArgument is one-based; this is false. It is zero-based. Trying to get the `1`st argument of a method that takes one argument will fail; taking the `0`th argument succeeds. This behavior should not be changed because hooks have already been written for it, but the documentation should be accurate.
2. The document did not mention the fact that omitting a return statement would throw an exception. Writing my second hook, I assumed that nil would be interpreted as false, but then I got spammed with errors and I found out that you do, in fact, have to explicitly return false.